### PR TITLE
Fix path resolution for Node 18

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,12 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import path from "path";
+import { fileURLToPath } from "url";
 import runtimeErrorOverlay from "@replit/vite-plugin-runtime-error-modal";
+
+// Compute __dirname for compatibility with older Node versions that do not
+// support `import.meta.dirname`
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   plugins: [
@@ -18,14 +23,14 @@ export default defineConfig({
   ],
   resolve: {
     alias: {
-      "@": path.resolve(import.meta.dirname, "client", "src"),
-      "@shared": path.resolve(import.meta.dirname, "shared"),
-      "@assets": path.resolve(import.meta.dirname, "attached_assets"),
+      "@": path.resolve(__dirname, "client", "src"),
+      "@shared": path.resolve(__dirname, "shared"),
+      "@assets": path.resolve(__dirname, "attached_assets"),
     },
   },
-  root: path.resolve(import.meta.dirname, "client"),
+  root: path.resolve(__dirname, "client"),
   build: {
-    outDir: path.resolve(import.meta.dirname, "dist/public"),
+    outDir: path.resolve(__dirname, "dist/public"),
     emptyOutDir: true,
   },
   server: {


### PR DESCRIPTION
## Summary
- compute __dirname via fileURLToPath in vite.config.ts
- resolve project paths using __dirname to avoid import.meta.dirname

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`
- `npm run build`
- `npx --yes node@18 dist/index.js`

------
https://chatgpt.com/codex/tasks/task_e_68a0205179a0832986324fd9f4ba5945