### PR TITLE
Fix pdf-parse import causing server crash

### DIFF
--- a/server/fileProcessor.ts
+++ b/server/fileProcessor.ts
@@ -1,5 +1,8 @@
 import { ObjectStorageService } from "./objectStorage";
-import pdfParse from "pdf-parse";
+// Import the library directly from its implementation file to avoid
+// running the debug code in the package's default entry point, which
+// tries to read a non-existent test PDF and crashes in production.
+import pdfParse from "pdf-parse/lib/pdf-parse.js";
 
 export async function extractRealFileContent(fileUrl: string, fileName: string): Promise<string> {
   try {

--- a/server/pdf-parse-lib.d.ts
+++ b/server/pdf-parse-lib.d.ts
@@ -1,0 +1,4 @@
+declare module 'pdf-parse/lib/pdf-parse.js' {
+  import pdfParse from 'pdf-parse';
+  export default pdfParse;
+}


### PR DESCRIPTION
## Summary
- avoid pdf-parse debug import that reads missing test file
- add type declaration for pdf-parse lib import

## Testing
- `npm test` *(fails: Missing script)*
- `npm run check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a02dff63848329aab249efdc220b65